### PR TITLE
pc - remove line from init.sh that deletes init.sh after running

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -4,4 +4,3 @@ rm -rf allolib
 rm -rf al_ext
 
 git submodule update --init --recursive
-rm init.sh


### PR DESCRIPTION
This PR removes the line `rm init.sh` from the end of `init.sh`.

It doesn't make sense to get rid of this file after running once, since the operations in this file need to be done each time you change from one commit of allolib_playground to another (e.g. when doing 'git bisect' to troubleshoot a problem.)

In addition, it creates a 'change' that has to be 'undone' if you are committing something to GitHub.  This is confusing for novices, which is at odds with the stated goal of allolib_playground, i.e. to be a place where beginners can get started with as little confusion as possible.